### PR TITLE
chore: feed content query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.0.2
+
+- chore: feed content query
+
 ## 2.0.1
 
 - chore: upgrade sghi_core package

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Release](https://img.shields.io/badge/Version-^2.0.1-success.svg?style=for-the-badge)](https://shields.io/)
+[![Release](https://img.shields.io/badge/Version-^2.0.2-success.svg?style=for-the-badge)](https://shields.io/)
 [![Maintained](https://img.shields.io/badge/Maintained-Actively-informational.svg?style=for-the-badge)](https://shields.io/)
 [![Release](https://img.shields.io/badge/Coverage-100-success.svg?style=for-the-badge)](https://shields.io/)
 
@@ -22,7 +22,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```dart
 dependencies:
-  bewell_pro_core: ^2.0.1
+  bewell_pro_core: ^2.0.2
 ```
 
 Alternatively, your editor might support flutter pub get. Check the docs for your editor to learn more.

--- a/lib/application/core/graphql/queries.dart
+++ b/lib/application/core/graphql/queries.dart
@@ -36,14 +36,17 @@ Map<String, dynamic> getFAQQueryVariables() {
   return <String, dynamic>{'flavour': Flavour.PRO.name};
 }
 
+//TODO: Debug backend for persistent as it does not allow BOTH as variable. Leads to server timeout
 Map<String, dynamic> getFeedQueryVariables() {
   return <String, dynamic>{
     'flavour': Flavour.PRO.name,
-    'persistent': 'BOTH',
+    'persistent': 'FALSE',
     'isAnonymous': false,
   };
 }
 
+
+//TODO: Debug backend for the icon image url. Current link leads to dead url, needs updating.
 // Feed content query
 const String getFeedContentQuery = r'''
 query GetFeed(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -273,7 +273,7 @@ packages:
       name: connectivity_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -448,7 +448,7 @@ packages:
       name: device_info_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   diacritic:
     dependency: transitive
     description:
@@ -1149,7 +1149,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   numerus:
     dependency: transitive
     description:
@@ -1450,7 +1450,7 @@ packages:
       name: sghi_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.12"
+    version: "0.2.13"
   share_plus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bewell_pro_core
 description: Main package for Slade Advantage
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/savannahghi/bewell_pro_core
 repository: https://github.com/savannahghi/bewell_pro_core
 issue_tracker: https://github.com/savannahghi/bewell_pro_core/issues


### PR DESCRIPTION
API query returned error every time it was called. The source was one of the variables could only allow either 'FALSE' or 'TRUE' but not 'BOTH'. This might be caused by a backend issue. Currently the variable value is set to 'FALSE' and allows accurate results to be returned.